### PR TITLE
Fix: Enforce geolocation for clock-in and clock-out.

### DIFF
--- a/attendance/static/attendance/clocking.html
+++ b/attendance/static/attendance/clocking.html
@@ -88,12 +88,10 @@
                         longitude: pos.coords.longitude
                     });
                 }, function(err) {
-                    // Geolocation failed, try to clock in without it
-                    makeRequest("clock-in");
+                    alert("Geolocation is required to clock in. Please enable location services and try again.");
                 });
             } else {
-                // Geolocation not supported, try to clock in without it
-                makeRequest("clock-in");
+                alert("Geolocation is not supported by this browser.");
             }
         }
 
@@ -113,12 +111,10 @@
                         longitude: pos.coords.longitude
                     });
                 }, function(err) {
-                    // Geolocation failed, try to clock out without it
-                    makeRequest("clock-out");
+                    alert("Geolocation is required to clock out. Please enable location services and try again.");
                 });
             } else {
-                // Geolocation not supported, try to clock out without it
-                makeRequest("clock-out");
+                alert("Geolocation is not supported by this browser.");
             }
         }
 


### PR DESCRIPTION
This change modifies the frontend to require geolocation data before sending a clock-in or clock-out request.

Previously, if the browser's geolocation service failed or was disabled, the application would still send the request to the server without location data. This allowed users to bypass the geolocation check.

The `clockIn` and `clockOut` JavaScript functions in `clocking.html` have been updated. Now, if geolocation is not available, the user is shown an alert and the request is not sent.

This addresses the immediate client-side vulnerability. For enhanced security, future work could include adding a server-side check to reject clocking attempts that lack location data.