### PR TITLE
This commit introduces a new User Profile page.

### DIFF
--- a/attendance/static/attendance/js/clocking.js
+++ b/attendance/static/attendance/js/clocking.js
@@ -76,6 +76,7 @@ async function attemptFaceLogin() {
             stopCamera();
             document.getElementById('camera-container').style.display = 'none';
             document.getElementById('clocking-controls').style.display = 'block';
+            document.getElementById('nav-links').style.display = 'inline';
             document.getElementById('user-greeting').innerHTML = `Welcome, <span class="fw-bold text-primary">${data.username}</span>!`;
             showNotification('Logged in successfully!', 'success');
         }

--- a/attendance/templates/attendance/clocking.html
+++ b/attendance/templates/attendance/clocking.html
@@ -6,7 +6,12 @@
 {% block content %}
 <div class="d-flex flex-column justify-content-center align-items-center">
     <div class="col-md-8 col-lg-6">
-        <h1 id="user-greeting">Please look at the camera to log in...</h1>
+        <div class="text-center">
+            <h1 id="user-greeting" class="d-inline">Please look at the camera to log in...</h1>
+            <div id="nav-links" class="d-inline" style="display: none;">
+                <a href="{% url 'profile_page' %}">(My Profile)</a>
+            </div>
+        </div>
 
     <div id="camera-container" class="text-center mb-4">
         <video id="video" width="320" height="240" autoplay playsinline class="border rounded"></video>

--- a/attendance/templates/attendance/profile.html
+++ b/attendance/templates/attendance/profile.html
@@ -1,0 +1,72 @@
+{% extends 'attendance/base.html' %}
+
+{% block title %}My Profile - TimeGate{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">
+                <h3>My Profile</h3>
+            </div>
+            <div class="card-body text-center">
+                {% if user.profile.reference_image %}
+                    <img src="{{ user.profile.reference_image.url }}" alt="Reference Image" class="img-fluid rounded-circle mb-3" style="width: 150px; height: 150px; object-fit: cover;">
+                {% else %}
+                    <div class="alert alert-warning">No reference image uploaded.</div>
+                {% endif %}
+
+                <h4>{{ user.get_full_name }}</h4>
+                <p class="text-muted">{{ user.username }}</p>
+                <p><strong>Phone:</strong> {{ user.profile.phone_number|default:"Not set" }}</p>
+
+                <hr>
+
+                <h5>Update Profile Picture</h5>
+                <form method="post" enctype="multipart/form-data" class="mt-3">
+                    {% csrf_token %}
+                    <div class="mb-3">
+                        <input type="file" name="reference_image" class="form-control" accept="image/*" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Upload New Picture</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-8">
+        <h3>My Attendance History</h3>
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead class="table-dark">
+                    <tr>
+                        <th>Date</th>
+                        <th>Clock In</th>
+                        <th>Clock Out</th>
+                        <th>Total Time</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for attendance in attendances %}
+                    <tr>
+                        <td>{{ attendance.date }}</td>
+                        <td>{{ attendance.clock_in|time:"H:i:s" }}</td>
+                        <td>{{ attendance.clock_out|time:"H:i:s"|default:"--" }}</td>
+                        <td>
+                            {% if attendance.total_seconds > 0 %}
+                                {{ attendance.total_seconds // 3600 }}h {{ (attendance.total_seconds % 3600) // 60 }}m
+                            {% else %}
+                                --
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="4" class="text-center p-4">No attendance records found.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/attendance/views.py
+++ b/attendance/views.py
@@ -207,6 +207,9 @@ class ClockOutView(APIView):
         return Response(AttendanceSerializer(att).data)
 
 from django.shortcuts import render, redirect
+from django.views import View
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib import messages
 from .forms import UserRegistrationForm
 
 
@@ -234,6 +237,25 @@ def register(request):
     else:
         form = UserRegistrationForm()
     return render(request, 'attendance/register.html', {'form': form})
+
+
+class UserProfileView(LoginRequiredMixin, View):
+    def get(self, request):
+        attendances = Attendance.objects.filter(user=request.user).order_by('-date', '-clock_in')
+        context = {
+            'attendances': attendances
+        }
+        return render(request, 'attendance/profile.html', context)
+
+    def post(self, request):
+        new_image = request.FILES.get('reference_image')
+        if new_image:
+            profile = request.user.profile
+            profile.reference_image = new_image
+            profile.save()
+            messages.success(request, 'Your profile picture has been updated successfully!')
+
+        return redirect('profile_page')
 
 
 class FaceLoginView(APIView):

--- a/attendance/web_urls.py
+++ b/attendance/web_urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import register, clocking_page
+from .views import register, clocking_page, UserProfileView
 
 urlpatterns = [
     path("", clocking_page, name="clocking_page"),
     path("register/", register, name="register"),
+    path("profile/", UserProfileView.as_view(), name="profile_page"),
 ]


### PR DESCRIPTION
Authenticated users can now navigate to a `/profile` page to:
- View their personal details (name, phone number).
- See their current reference photo used for facial recognition.
- Upload a new reference photo.
- View a complete history of their attendance records in a tabular format.

This feature includes a new `UserProfileView`, a corresponding URL, and a new `profile.html` template styled with Bootstrap. A navigation link has been added to the clocking page for easy access.